### PR TITLE
Extract Banned Apps Feature Into Standalone Static App

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# 🍞 Panini - Banned Apps Visualization
+
+**Panini** is a static web application that visualizes apps banned by different countries around the world. It provides both a list view and an interactive map view to explore censorship data.
+
+This project was extracted from the [OWASP BLT](https://github.com/OWASP-BLT/BLT) project to serve as a standalone visualization suitable for GitHub Pages.
+
+## ✨ Features
+
+- **🌍 Interactive Map View**: Visualize banned apps directly on a global map. Countries with bans are highlighted, and clicking them reveals details.
+- **📋 List View**: A clean, responsive list of all banned apps, sortable and filterable.
+- **🔍 Smart Search**: Search by country or app name.
+  - In **Map View**, searching for a country automatically zooms to and highlights it!
+- **lighting Dark Mode**: Fully supported dark mode for comfortable viewing at night.
+- **📱 Responsive Design**: Works seamlessly on desktop and mobile devices.
+
+## 🚀 Quick Start
+
+Since this is a static site, you don't need a backend server.
+
+### Live Demo
+
+## 🛠️ Technologies
+
+- **HTML5**
+- **Tailwind CSS** (via CDN)
+- **Leaflet.js** (for maps)
+- **Vanilla JavaScript** (no heavy frameworks)
+
+## 📂 Data
+
+The data is stored in `banned_apps.json` in a structured format, making it easy to update or expand.
+
+## 🤝 Contributing
+
+1. Fork the repository.
+2. Create your feature branch (`git checkout -b feature/AmazingFeature`).
+3. Commit your changes (`git commit -m 'Add some AmazingFeature'`).
+4. Push to the branch (`git push origin feature/AmazingFeature`).
+5. Open a Pull Request.
+
+## 📄 License
+
+This project is open source. See the [LICENSE](LICENSE) file for details.

--- a/banned_apps.json
+++ b/banned_apps.json
@@ -1,0 +1,227 @@
+[
+    {
+        "model": "website.bannedapp",
+        "fields": {
+            "country_name": "India",
+            "country_code": "IN",
+            "app_name": "TikTok",
+            "app_type": "social",
+            "ban_reason": "Security concerns and data privacy issues",
+            "ban_date": "2020-06-29",
+            "source_url": "https://www.bbc.com/news/world-asia-india-53234116",
+            "is_active": true,
+            "created_at": "2024-03-13T00:00:00Z",
+            "updated_at": "2024-03-13T00:00:00Z"
+        }
+    },
+    {
+        "model": "website.bannedapp",
+        "fields": {
+            "country_name": "India",
+            "country_code": "IN",
+            "app_name": "PUBG Mobile",
+            "app_type": "gaming",
+            "ban_reason": "Security concerns and addiction-related issues",
+            "ban_date": "2020-09-02",
+            "source_url": "https://indianexpress.com/article/technology/gaming/pubg-mobile-ban-in-india-explained-6581277/",
+            "is_active": true,
+            "created_at": "2024-03-13T00:00:00Z",
+            "updated_at": "2024-03-13T00:00:00Z"
+        }
+    },
+    {
+        "model": "website.bannedapp",
+        "fields": {
+            "country_name": "China",
+            "country_code": "CN",
+            "app_name": "Facebook",
+            "app_type": "social",
+            "ban_reason": "Government censorship and internet regulations",
+            "ban_date": "2009-07-01",
+            "source_url": "https://www.bbc.com/news/technology-40449959",
+            "is_active": true,
+            "created_at": "2024-03-13T00:00:00Z",
+            "updated_at": "2024-03-13T00:00:00Z"
+        }
+    },
+    {
+        "model": "website.bannedapp",
+        "fields": {
+            "country_name": "China",
+            "country_code": "CN",
+            "app_name": "WhatsApp",
+            "app_type": "messaging",
+            "ban_reason": "Government censorship and national security concerns",
+            "ban_date": "2017-09-25",
+            "source_url": "https://www.nytimes.com/2017/09/25/business/china-whatsapp-blocked.html",
+            "is_active": true,
+            "created_at": "2024-03-13T00:00:00Z",
+            "updated_at": "2024-03-13T00:00:00Z"
+        }
+    },
+    {
+        "model": "website.bannedapp",
+        "fields": {
+            "country_name": "Russia",
+            "country_code": "RU",
+            "app_name": "LinkedIn",
+            "app_type": "social",
+            "ban_reason": "Violation of data storage laws",
+            "ban_date": "2016-11-17",
+            "source_url": "https://www.bbc.com/news/world-europe-38005238",
+            "is_active": true,
+            "created_at": "2024-03-13T00:00:00Z",
+            "updated_at": "2024-03-13T00:00:00Z"
+        }
+    },
+    {
+        "model": "website.bannedapp",
+        "fields": {
+            "country_name": "Iran",
+            "country_code": "IR",
+            "app_name": "Telegram",
+            "app_type": "messaging",
+            "ban_reason": "Government censorship and national security concerns",
+            "ban_date": "2018-04-30",
+            "source_url": "https://www.reuters.com/article/us-iran-telegram/iran-bans-telegram-app-to-protect-national-security-state-tv-idUSKBN1I11A5",
+            "is_active": true,
+            "created_at": "2024-03-13T00:00:00Z",
+            "updated_at": "2024-03-13T00:00:00Z"
+        }
+    },
+    {
+        "model": "website.bannedapp",
+        "fields": {
+            "country_name": "United States",
+            "country_code": "US",
+            "app_name": "Huawei AppGallery",
+            "app_type": "other",
+            "ban_reason": "National security concerns",
+            "ban_date": "2019-05-15",
+            "source_url": "https://www.theverge.com/2019/5/20/18632722/huawei-google-android-ban-trump-executive-order",
+            "is_active": true,
+            "created_at": "2024-03-13T00:00:00Z",
+            "updated_at": "2024-03-13T00:00:00Z"
+        }
+    },
+    {
+        "model": "website.bannedapp",
+        "fields": {
+            "country_name": "India",
+            "country_code": "IN",
+            "app_name": "WeChat",
+            "app_type": "social",
+            "ban_reason": "Security concerns and data privacy issues",
+            "ban_date": "2020-06-29",
+            "source_url": "https://www.bbc.com/news/world-asia-india-53232486",
+            "is_active": true,
+            "created_at": "2024-03-13T00:00:00Z",
+            "updated_at": "2024-03-13T00:00:00Z"
+        }
+    },
+    {
+        "model": "website.bannedapp",
+        "fields": {
+            "country_name": "India",
+            "country_code": "IN",
+            "app_name": "UC Browser",
+            "app_type": "browser",
+            "ban_reason": "Security concerns and data privacy issues",
+            "ban_date": "2020-06-29",
+            "source_url": "https://www.bbc.com/news/world-asia-india-53232486",
+            "is_active": true,
+            "created_at": "2024-03-13T00:00:00Z",
+            "updated_at": "2024-03-13T00:00:00Z"
+        }
+    },
+    {
+        "model": "website.bannedapp",
+        "fields": {
+            "country_name": "India",
+            "country_code": "IN",
+            "app_name": "CamScanner",
+            "app_type": "productivity",
+            "ban_reason": "Security concerns and data privacy issues",
+            "ban_date": "2020-06-29",
+            "source_url": "https://www.bbc.com/news/world-asia-india-53232486",
+            "is_active": true,
+            "created_at": "2024-03-13T00:00:00Z",
+            "updated_at": "2024-03-13T00:00:00Z"
+        }
+    },
+    {
+        "model": "website.bannedapp",
+        "fields": {
+            "country_name": "India",
+            "country_code": "IN",
+            "app_name": "ShareIt",
+            "app_type": "file sharing",
+            "ban_reason": "Security concerns and data privacy issues",
+            "ban_date": "2020-06-29",
+            "source_url": "https://www.bbc.com/news/world-asia-india-53232486",
+            "is_active": true,
+            "created_at": "2024-03-13T00:00:00Z",
+            "updated_at": "2024-03-13T00:00:00Z"
+        }
+    },
+    {
+        "model": "website.bannedapp",
+        "fields": {
+            "country_name": "India",
+            "country_code": "IN",
+            "app_name": "Shein",
+            "app_type": "e-commerce",
+            "ban_reason": "Security concerns and data privacy issues",
+            "ban_date": "2020-06-29",
+            "source_url": "https://www.bbc.com/news/world-asia-india-53232486",
+            "is_active": true,
+            "created_at": "2024-03-13T00:00:00Z",
+            "updated_at": "2024-03-13T00:00:00Z"
+        }
+    },
+    {
+        "model": "website.bannedapp",
+        "fields": {
+            "country_name": "India",
+            "country_code": "IN",
+            "app_name": "Likee",
+            "app_type": "social",
+            "ban_reason": "Security concerns and data privacy issues",
+            "ban_date": "2020-06-29",
+            "source_url": "https://indianexpress.com/article/technology/tech-news-technology/year-of-the-banned-tiktok-to-pubg-mobile-all-the-apps-that-stopped-working-in-india-in-2020-7118174/",
+            "is_active": true,
+            "created_at": "2024-03-13T00:00:00Z",
+            "updated_at": "2024-03-13T00:00:00Z"
+        }
+    },
+    {
+        "model": "website.bannedapp",
+        "fields": {
+            "country_name": "India",
+            "country_code": "IN",
+            "app_name": "Battlegrounds Mobile India (BGMI)",
+            "app_type": "gaming",
+            "ban_reason": "Security concerns",
+            "ban_date": "2022-07-28",
+            "source_url": "https://www.bbc.com/news/world-asia-india-62344926",
+            "is_active": true,
+            "created_at": "2024-03-13T00:00:00Z",
+            "updated_at": "2024-03-13T00:00:00Z"
+        }
+    },
+    {
+        "model": "website.bannedapp",
+        "fields": {
+            "country_name": "India",
+            "country_code": "IN",
+            "app_name": "Weibo",
+            "app_type": "social",
+            "ban_reason": "Security concerns and data privacy issues",
+            "ban_date": "2020-06-29",
+            "source_url": "https://en.wikipedia.org/wiki/Censorship_of_TikTok",
+            "is_active": true,
+            "created_at": "2024-03-13T00:00:00Z",
+            "updated_at": "2024-03-13T00:00:00Z"
+        }
+    }
+]

--- a/index.html
+++ b/index.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Banned Apps</title>
+    <!-- Tailwind CSS -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            darkMode: 'class',
+            theme: {
+                extend: {
+                    colors: {
+                        gray: {
+                            900: '#111827',
+                            800: '#1f2937',
+                            700: '#374151',
+                        }
+                    }
+                }
+            }
+        }
+    </script>
+    <!-- Leaflet CSS -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 min-h-screen transition-colors duration-200">
+    <div class="container mx-auto px-4 py-8">
+        <header class="flex justify-between items-center mb-8">
+            <h1 class="text-3xl font-bold text-center flex-grow">Search Banned Apps by Country</h1>
+            <button id="themeToggle" class="p-2 rounded-lg bg-gray-200 dark:bg-gray-800 text-gray-800 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-700 transition-colors">
+                <svg id="sunIcon" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                </svg>
+                <svg id="moonIcon" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                </svg>
+            </button>
+        </header>
+
+        <!-- Tab Navigation -->
+        <div class="max-w-xl mx-auto mb-6">
+            <div class="flex border-b border-gray-200 dark:border-gray-700">
+                <button id="listViewBtn" class="py-2 px-4 font-medium text-red-600 border-b-2 border-red-600 transition-colors duration-200">List View</button>
+                <button id="mapViewBtn" class="py-2 px-4 font-medium text-gray-500 dark:text-gray-400 hover:text-red-600 transition-colors duration-200">Map View</button>
+            </div>
+        </div>
+
+        <!-- Search Bar -->
+        <div class="max-w-xl mx-auto mb-8">
+            <input type="text" id="countrySearch" placeholder="Enter country name..." class="w-full px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 transition-colors duration-200 shadow-sm">
+        </div>
+
+        <!-- List View -->
+        <div id="listView">
+            <div id="resultsSection">
+                <h2 class="text-2xl font-semibold mb-4 ml-1">Banned Apps Results</h2>
+                <div id="appsGrid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    <!-- Results will be inserted here -->
+                </div>
+            </div>
+            <!-- No Results Message -->
+            <div id="noResults" class="hidden text-center py-12">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mx-auto text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <p class="text-gray-600 dark:text-gray-400 text-lg">No banned apps found for this country.</p>
+            </div>
+        </div>
+
+        <!-- Map View -->
+        <div id="mapView" class="hidden relative">
+            <div id="map" class="h-[600px] w-full rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 z-0"></div>
+            
+            <!-- Floating Country Info Panel -->
+            <div id="countryInfo" class="absolute top-4 right-4 z-[400] w-80 max-h-[550px] overflow-y-auto bg-white/95 dark:bg-gray-800/95 backdrop-blur-sm rounded-xl shadow-2xl border border-gray-200 dark:border-gray-700 p-5 hidden transition-all duration-300 transform translate-x-0">
+                <div class="flex justify-between items-start mb-3">
+                    <h3 id="countryName" class="text-xl font-bold text-gray-900 dark:text-white"></h3>
+                    <button id="closeInfoBtn" class="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                            <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+                        </svg>
+                    </button>
+                </div>
+                <p id="bannedAppsCount" class="text-sm font-semibold text-red-600 mb-4 bg-red-50 dark:bg-red-900/20 py-1 px-2 rounded inline-block"></p>
+                <div id="bannedAppsList" class="space-y-3"></div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Leaflet JS -->
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+    <!-- Custom JS -->
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,400 @@
+
+// State
+let allApps = [];
+let map;
+let countriesLayer;
+let markersLayer;
+let allCountriesData = {};
+let geoJSONLoaded = false;
+let currentView = 'list';
+
+// DOM Elements
+const searchInput = document.getElementById('countrySearch');
+const listViewBtn = document.getElementById('listViewBtn');
+const mapViewBtn = document.getElementById('mapViewBtn');
+const listView = document.getElementById('listView');
+const mapView = document.getElementById('mapView');
+const resultsSection = document.getElementById('resultsSection');
+const appsGrid = document.getElementById('appsGrid');
+const noResults = document.getElementById('noResults');
+const countryInfo = document.getElementById('countryInfo');
+const themeToggle = document.getElementById('themeToggle');
+const sunIcon = document.getElementById('sunIcon');
+const moonIcon = document.getElementById('moonIcon');
+
+// Initialization
+document.addEventListener('DOMContentLoaded', async () => {
+    // Check system preference for dark mode
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        document.documentElement.classList.add('dark');
+        updateThemeIcon(true);
+    }
+
+    try {
+        const response = await fetch('banned_apps.json');
+        const data = await response.json();
+        // Parse Django fixture format
+        allApps = data.map(item => ({
+            ...item.fields,
+            id: item.pk // keeping pk if needed though not used extensively
+        }));
+
+        // Initial render
+        renderApps(allApps);
+    } catch (error) {
+        console.error('Error loading banned apps data:', error);
+        appsGrid.innerHTML = '<p class="text-red-500">Error loading data. Please check console.</p>';
+    }
+
+    // Set up event listeners
+    setupEventListeners();
+});
+
+function setupEventListeners() {
+    // Search
+    searchInput.addEventListener('input', debounce((e) => {
+        const query = e.target.value.trim().toLowerCase();
+        handleSearch(query);
+    }, 300));
+
+    // View Toggles
+    listViewBtn.addEventListener('click', () => switchView('list'));
+    mapViewBtn.addEventListener('click', () => switchView('map'));
+
+    // Theme Toggle
+    themeToggle.addEventListener('click', toggleTheme);
+
+    // Close Info Panel
+    document.getElementById('closeInfoBtn').addEventListener('click', () => {
+        countryInfo.classList.add('hidden');
+    });
+}
+
+function handleSearch(query) {
+    // Always reset map visuals/highlights first when searching
+    resetMapHighlights();
+
+    if (!query) {
+        renderApps(allApps);
+        if (currentView === 'map') resetMapVisuals();
+        return;
+    }
+
+    const filteredApps = allApps.filter(app =>
+        app.country_name.toLowerCase().includes(query) ||
+        app.app_name.toLowerCase().includes(query)
+    );
+
+    if (currentView === 'list') {
+        renderApps(filteredApps);
+    } else {
+        // Map view: Update markers? For now, we keep markers for all apps but highlight the searched country.
+        // If the query matches a country name, highlight it.
+        const matchedCountry = Object.keys(allCountriesData).find(c => c.includes(query));
+        if (matchedCountry) {
+            highlightCountry(matchedCountry, true);
+        }
+    }
+}
+
+function renderApps(apps) {
+    if (apps.length === 0) {
+        resultsSection.classList.add('hidden');
+        noResults.classList.remove('hidden');
+        return;
+    }
+
+    resultsSection.classList.remove('hidden');
+    noResults.classList.add('hidden');
+    appsGrid.innerHTML = '';
+
+    apps.forEach(app => {
+        const card = document.createElement('div');
+        card.className = 'bg-white dark:bg-gray-800 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 overflow-hidden border border-gray-100 dark:border-gray-700 flex flex-col';
+
+        card.innerHTML = `
+            <div class="p-6 flex-grow">
+                <div class="flex justify-between items-start mb-3">
+                    <h3 class="text-xl font-bold text-gray-900 dark:text-white">${app.app_name}</h3>
+                    <span class="px-2 py-1 text-xs font-semibold rounded bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200">
+                        ${app.country_name}
+                    </span>
+                </div>
+                <p class="text-sm font-medium text-gray-500 dark:text-gray-400 mb-3 uppercase tracking-wide">${app.app_type}</p>
+                <p class="text-gray-700 dark:text-gray-300 mb-4 line-clamp-3">${app.ban_reason}</p>
+            </div>
+            <div class="bg-gray-50 dark:bg-gray-700/50 px-6 py-4 border-t border-gray-100 dark:border-gray-700 flex justify-between items-center text-sm">
+                <span class="text-gray-500 dark:text-gray-400">Banned: ${new Date(app.ban_date).toLocaleDateString()}</span>
+                ${app.source_url ? `<a href="${app.source_url}" target="_blank" class="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 font-medium hover:underline inline-flex items-center">Source <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3 ml-1" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg></a>` : ''}
+            </div>
+        `;
+        appsGrid.appendChild(card);
+    });
+}
+
+function switchView(view) {
+    currentView = view;
+    if (view === 'list') {
+        listView.classList.remove('hidden');
+        mapView.classList.add('hidden');
+
+        listViewBtn.classList.add('text-red-600', 'border-b-2', 'border-red-600');
+        listViewBtn.classList.remove('text-gray-500', 'dark:text-gray-400');
+
+        mapViewBtn.classList.remove('text-red-600', 'border-b-2', 'border-red-600');
+        mapViewBtn.classList.add('text-gray-500', 'dark:text-gray-400');
+    } else {
+        listView.classList.add('hidden');
+        mapView.classList.remove('hidden');
+
+        mapViewBtn.classList.add('text-red-600', 'border-b-2', 'border-red-600');
+        mapViewBtn.classList.remove('text-gray-500', 'dark:text-gray-400');
+
+        listViewBtn.classList.remove('text-red-600', 'border-b-2', 'border-red-600');
+        listViewBtn.classList.add('text-gray-500', 'dark:text-gray-400');
+
+        if (!map) initMap();
+        else setTimeout(() => map.invalidateSize(), 100); // Fix Leaflet render on tab switch
+    }
+}
+
+// Map Functions
+function initMap() {
+    map = L.map('map').setView([20, 0], 2);
+
+    // Check for dark mode to set initial tile layer
+    const isDark = document.documentElement.classList.contains('dark');
+    const tileUrl = isDark
+        ? 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png'
+        : 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+
+    const attribution = isDark
+        ? '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
+        : '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+
+    const tileLayer = L.tileLayer(tileUrl, { attribution }).addTo(map);
+
+    // Save tileLayer reference to update on theme toggle if needed (advanced)
+
+    markersLayer = L.layerGroup().addTo(map);
+
+    fetch('https://raw.githubusercontent.com/datasets/geo-countries/master/data/countries.geojson')
+        .then(response => response.json())
+        .then(data => {
+            const features = data.features || [];
+            countriesLayer = L.geoJSON(features, {
+                style: getCountryStyle,
+                onEachFeature: onEachFeature
+            }).addTo(map);
+            geoJSONLoaded = true;
+
+            // Populate markers initially
+            placeMarkersForApps(allApps);
+        })
+        .catch(err => {
+            console.error("Error loading GeoJSON:", err);
+            geoJSONLoaded = true;
+        });
+}
+
+function getCountryStyle(feature) {
+    const isDark = document.documentElement.classList.contains('dark');
+    return {
+        fillColor: isDark ? "#374151" : "#f3f4f6",
+        weight: 1,
+        opacity: 1,
+        color: isDark ? "#4b5563" : "#d1d5db",
+        fillOpacity: 0.7
+    };
+}
+
+function onEachFeature(feature, layer) {
+    const countryName = (feature.properties.name || feature.properties.ADMIN || "").toLowerCase();
+    if (!countryName) return;
+
+    allCountriesData[countryName] = {
+        layer: layer,
+        feature: feature,
+        center: layer.getBounds().getCenter() // Approximation
+    };
+
+    layer.on({
+        mouseover: function (e) {
+            const layer = e.target;
+            const isDark = document.documentElement.classList.contains('dark');
+            layer.setStyle({
+                weight: 2,
+                color: isDark ? "#9ca3af" : "#6b7280",
+                fillOpacity: 0.9
+            });
+            layer.bringToFront();
+        },
+        mouseout: function (e) {
+            countriesLayer.resetStyle(e.target);
+            // Re-apply highlight if active? (Simplification: just reset)
+        },
+        click: function (e) {
+            // Maybe filter list by this country?
+            const clickedCountry = countryName;
+            // For now, just zoom
+            map.fitBounds(e.target.getBounds());
+
+            // Show info if apps exist
+            const apps = allApps.filter(app => app.country_name.toLowerCase() === clickedCountry);
+            if (apps.length > 0) {
+                showCountryInfo(clickedCountry, apps);
+            }
+        }
+    });
+}
+
+function placeMarkersForApps(apps) {
+    if (!markersLayer) return;
+    markersLayer.clearLayers();
+
+    // Group apps by country
+    const appsByCountry = {};
+    apps.forEach(app => {
+        const cLower = app.country_name.toLowerCase();
+        if (!appsByCountry[cLower]) appsByCountry[cLower] = [];
+        appsByCountry[cLower].push(app);
+    });
+
+    Object.entries(appsByCountry).forEach(([countryName, countryApps]) => {
+        const countryData = allCountriesData[countryName];
+        if (countryData) {
+            const center = countryData.layer.getBounds().getCenter();
+            const count = countryApps.length;
+
+            const markerHTML = `
+                <div class="relative w-10 h-10 group cursor-pointer transform hover:scale-110 transition-transform duration-200">
+                    <div class="absolute inset-0 bg-red-600 rounded-full opacity-75 animate-ping group-hover:animate-none"></div>
+                    <div class="absolute inset-0 bg-red-600 rounded-full flex items-center justify-center shadow-lg border-2 border-white dark:border-gray-800">
+                        <span class="text-white font-bold text-sm">${count}</span>
+                    </div>
+                </div>`;
+
+            const marker = L.marker(center, {
+                icon: L.divIcon({
+                    className: "",
+                    html: markerHTML,
+                    iconSize: [40, 40],
+                    iconAnchor: [20, 20]
+                })
+            });
+
+            marker.bindTooltip(`${countryApps[0].country_name}: ${count} banned apps`, {
+                direction: "top",
+                offset: [0, -20],
+                className: "bg-gray-800 text-white px-2 py-1 rounded text-xs"
+            });
+
+            marker.on('click', () => {
+                showCountryInfo(countryName, countryApps);
+                map.setView(center, 4);
+            });
+
+            markersLayer.addLayer(marker);
+        }
+    });
+}
+
+function showCountryInfo(countryName, apps) {
+    const titleName = countryName.charAt(0).toUpperCase() + countryName.slice(1);
+    document.getElementById('countryName').textContent = titleName;
+    document.getElementById('bannedAppsCount').textContent = `${apps.length} Banned Apps`;
+
+    const listDiv = document.getElementById('bannedAppsList');
+    listDiv.innerHTML = apps.map(app => `
+        <div class="p-3 rounded bg-gray-50 dark:bg-gray-700/50 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors border border-gray-100 dark:border-gray-600">
+            <h4 class="font-bold text-red-600 dark:text-red-400 text-sm">${app.app_name}</h4>
+            <p class="text-xs text-gray-500 dark:text-gray-400 uppercase mt-0.5">${app.app_type}</p>
+            <p class="text-xs text-gray-700 dark:text-gray-300 mt-1 line-clamp-2">${app.ban_reason}</p>
+        </div>
+    `).join('');
+
+    countryInfo.classList.remove('hidden');
+}
+
+function highlightCountry(countryName, isActive) {
+    if (!map || !countriesLayer) return;
+
+    const lower = countryName.toLowerCase();
+    const countryData = allCountriesData[lower];
+
+    if (countryData) {
+        if (isActive) {
+            const layer = countryData.layer;
+            const isDark = document.documentElement.classList.contains('dark');
+
+            layer.setStyle({
+                fillColor: '#ef4444',
+                weight: 2,
+                color: isDark ? '#fca5a5' : '#b91c1c',
+                fillOpacity: 0.6
+            });
+
+            layer.bringToFront();
+            map.fitBounds(layer.getBounds(), { padding: [50, 50] });
+
+            const popup = L.popup()
+                .setLatLng(layer.getBounds().getCenter())
+                .setContent(`<div class="text-center font-bold px-2 py-1">${countryName.toUpperCase()}</div>`)
+                .openOn(map);
+        }
+    }
+}
+
+function resetMapHighlights() {
+    if (countriesLayer) {
+        countriesLayer.eachLayer(layer => {
+            countriesLayer.resetStyle(layer);
+        });
+    }
+    if (map) {
+        map.closePopup();
+    }
+}
+
+function resetMapVisuals() {
+    resetMapHighlights();
+    if (countryInfo) countryInfo.classList.add('hidden');
+    if (map) map.setView([20, 0], 2);
+}
+
+// Utility
+function debounce(func, wait) {
+    let timeout;
+    return function (...args) {
+        clearTimeout(timeout);
+        timeout = setTimeout(() => func(...args), wait);
+    };
+}
+
+// Theme
+function toggleTheme() {
+    const html = document.documentElement;
+    if (html.classList.contains('dark')) {
+        html.classList.remove('dark');
+        updateThemeIcon(false);
+    } else {
+        html.classList.add('dark');
+        updateThemeIcon(true);
+    }
+
+    // Re-initialize map tiles if necessary (simple reload or layer swap)
+    if (map) {
+        map.remove();
+        initMap(); // Simplest way to swap tile styles properly
+    }
+}
+
+function updateThemeIcon(isDark) {
+    if (isDark) {
+        sunIcon.classList.remove('hidden');
+        moonIcon.classList.add('hidden');
+    } else {
+        sunIcon.classList.add('hidden');
+        moonIcon.classList.remove('hidden');
+    }
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,54 @@
+/* Custom Scrollbar for Webkit */
+::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+
+::-webkit-scrollbar-track {
+    background: transparent; 
+}
+
+::-webkit-scrollbar-thumb {
+    background: #cbd5e1; 
+    border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: #94a3b8; 
+}
+
+.dark ::-webkit-scrollbar-thumb {
+    background: #4b5563; 
+}
+
+.dark ::-webkit-scrollbar-thumb:hover {
+    background: #6b7280; 
+}
+
+/* Leaflet Map Overrides */
+.leaflet-popup-content-wrapper {
+    border-radius: 0.5rem;
+    padding: 0;
+    overflow: hidden;
+}
+
+.leaflet-popup-content {
+    margin: 0.5rem 1rem;
+    line-height: 1.4;
+}
+
+.dark .leaflet-container {
+    background: #1f2937;
+}
+
+/* Animations */
+@keyframes ping {
+    75%, 100% {
+        transform: scale(2);
+        opacity: 0;
+    }
+}
+
+.animate-ping {
+    animation: ping 1s cubic-bezier(0, 0, 0.2, 1) infinite;
+}


### PR DESCRIPTION
## Summary
This PR removes the banned-apps functionality from BLT and recreates it as a standalone static visualization app suitable for GitHub Pages. The goal is to separate non-core features and keep BLT’s codebase focused while still preserving the banned-apps tool in an accessible public format.

## What’s Included

- Added Banned Apps Visualization, a static HTML/CSS/JS app
- Standalone interactive map + list view
- Fully client-side (no Python/Django dependencies)
- Added banned_apps.json fixture extracted from BLT
- Tailwind-based UI with dark mode
- Leaflet-based map to show bans globally
- Responsive design optimized for GitHub Pages

## Why This Change

- The banned-apps module is being removed from BLT
- Its functionality is preserved in a static version instead of being deleted
- No backend or BLT models needed anymore
- Lightweight, fast to host, and easy to maintain separately

<img width="1900" height="910" alt="Screenshot 2026-02-09 122944" src="https://github.com/user-attachments/assets/a23812a6-f6b0-4a00-bd49-5fb5fe3caf60" />
<img width="1897" height="941" alt="image" src="https://github.com/user-attachments/assets/c5a0d6d0-6814-4046-b56e-c17bba18be4f" />
Closes: #1 