### PR TITLE
Fix: broken Details link for PUBG Mobile card

### DIFF
--- a/banned_apps.json
+++ b/banned_apps.json
@@ -23,7 +23,7 @@
             "app_type": "gaming",
             "ban_reason": "Security concerns and addiction-related issues",
             "ban_date": "2020-09-02",
-            "source_url": "https://www.bbc.com/news/world-asia-india-62344926",
+            "source_url": "https://www.hindustantimes.com/india-news/govt-bans-118-more-mobile-apps-including-pubg/story-BJqtksETjNxMLJbBLrodPP.html",
             "is_active": true,
             "created_at": "2024-03-13T00:00:00Z",
             "updated_at": "2024-03-13T00:00:00Z"

--- a/banned_apps.json
+++ b/banned_apps.json
@@ -23,7 +23,7 @@
             "app_type": "gaming",
             "ban_reason": "Security concerns and addiction-related issues",
             "ban_date": "2020-09-02",
-            "source_url": "https://indianexpress.com/article/technology/gaming/pubg-mobile-ban-in-india-explained-6581277/",
+            "source_url": "https://www.bbc.com/news/world-asia-india-62344926",
             "is_active": true,
             "created_at": "2024-03-13T00:00:00Z",
             "updated_at": "2024-03-13T00:00:00Z"


### PR DESCRIPTION
Fixes #19 

## Description
This PR fixes the issue where the "Details" link in the PUBG Mobile card was leading to Page Not Found.

## Changes Made
-Updated the incorrect URL in the JSON data
-Ensured the link points to a valid page

## Testing
-Verified that clicking the "Details" link now redirects correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the source reference for a banned-app record (PUBG Mobile — India) to a more authoritative news source to improve data accuracy and source credibility; no other data fields were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->